### PR TITLE
Fix all 7 bugs in CLI 2048 game

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -1,8 +1,3 @@
-=begin
-    Bugs:
-    1. Game ends once grid is full even if more moves can be made
-    2. Combines successively when it shouldn't
-=end
 def play
     puts "---- 2048 ----"
     print "Enter grid length: "
@@ -16,8 +11,8 @@ def play
     $grid = Array.new($l) { Array.new($l) }
     new_block()
     display()
-        
-    while !full?() & !game_over?()
+
+    while !game_over?()
         $valid_move = false
         print "Up, Down, Right or Left? "
         input = gets.chomp
@@ -30,9 +25,7 @@ def play
         display()
     end
 
-    print "Up, Down, Right or Left? "
-    input = gets.chomp
-    move(input.upcase)
+    puts "Game over!"
 end
 
 def full?
@@ -50,7 +43,7 @@ def move(input)
         down()
     when "D"
         right()
-    when Fixnum
+    when Integer
         print "You entered a number. Choose a direction (W,A,S,D): "
         input = gets.chomp
         move(input.upcase)
@@ -62,43 +55,32 @@ def move(input)
 end
 
 def up
+    merged = Array.new($l) { Array.new($l, false) }
     for r in 1...$l
         for c in 0...$l
             if $grid[r][c] != nil
-                # puts "Cell: " + r.to_s + ", " + c.to_s
-                # if cell above is empty, shift up
                 new_r = -1
                 for i in 1..r
-                    # print "Cell above: " + (r-i).to_s + ", " + c.to_s
                     if $grid[r-i][c] == nil
-                        # puts " is empty"
-                        # if block directly above is empty, update new row to move to
                         new_r = r - i
                     else
-                        # puts " is not empty"
                         break
                     end
                 end
                 if new_r != -1
-                    # puts "new_r was updated"
                     $grid[new_r][c] = $grid[r][c]
                     $grid[r][c] = nil
                     $valid_move = true
-                    # if $grid[r][c] == nil
-                    #     display()
-                    # end
-                    if new_r > 0 && $grid[new_r-1][c] == $grid[new_r][c]
-                        # puts "Can combine"
+                    if new_r > 0 && !merged[new_r-1][c] && $grid[new_r-1][c] == $grid[new_r][c]
                         $grid[new_r-1][c] *= 2
                         $grid[new_r][c] = nil
-                        display()
+                        merged[new_r-1][c] = true
                     end
-                elsif r > 0 && $grid[r-1][c] == $grid[r][c]
-                    # puts "Can combine"
+                elsif r > 0 && !merged[r-1][c] && $grid[r-1][c] == $grid[r][c]
                     $grid[r-1][c] *= 2
                     $grid[r][c] = nil
                     $valid_move = true
-                    # display()
+                    merged[r-1][c] = true
                 end
             end
         end
@@ -106,39 +88,32 @@ def up
 end
 
 def down
+    merged = Array.new($l) { Array.new($l, false) }
     for r in ($l-2).downto(0)
         for c in 0...$l
             if $grid[r][c] != nil
-                # puts "Cell: " + r.to_s + ", " + c.to_s
-                # if cell below is empty, shift down
                 new_r = -1
                 for i in 1...($l-r)
-                    # print "Cell below: " + (r+i).to_s + ", " + c.to_s
                     if $grid[r+i][c] == nil
-                        # puts " is empty"
-                        # if block directly below is empty, update new row to move to
                         new_r = r + i
                     else
-                        # puts " is not empty"
                         break
                     end
                 end
                 if new_r != -1
-                    # puts "new_r was updated"
                     $grid[new_r][c] = $grid[r][c]
                     $grid[r][c] = nil
                     $valid_move = true
-                    if new_r < $l - 1 && $grid[new_r+1][c] == $grid[new_r][c]
-                        # puts "Can combine"
+                    if new_r < $l - 1 && !merged[new_r+1][c] && $grid[new_r+1][c] == $grid[new_r][c]
                         $grid[new_r+1][c] *= 2
                         $grid[new_r][c] = nil
+                        merged[new_r+1][c] = true
                     end
-                elsif r < $l - 1 && $grid[r+1][c] == $grid[r][c]
-                    # puts "Can combine"
+                elsif r < $l - 1 && !merged[r+1][c] && $grid[r+1][c] == $grid[r][c]
                     $grid[r+1][c] *= 2
                     $grid[r][c] = nil
                     $valid_move = true
-                    # display()
+                    merged[r+1][c] = true
                 end
             end
         end
@@ -146,39 +121,32 @@ def down
 end
 
 def right
+    merged = Array.new($l) { Array.new($l, false) }
     for r in 0...$l
         for c in ($l-2).downto(0)
             if $grid[r][c] != nil
-                # puts "Cell: " + r.to_s + ", " + c.to_s
-                # if cell right is empty, shift right
                 new_c = -1
                 for i in 1...($l-c)
-                    # print "Cell right: " + r.to_s + ", " + (c+i).to_s
                     if $grid[r][c+i] == nil
-                        # puts " is empty"
-                        # if block immediately right is empty, update new col to move to
                         new_c = c + i
                     else
-                        # puts " is not empty"
                         break
                     end
                 end
                 if new_c != -1
-                    # puts "new_c was updated"
                     $grid[r][new_c] = $grid[r][c]
                     $grid[r][c] = nil
                     $valid_move = true
-                    if new_c < $l - 1 && $grid[r][new_c+1] == $grid[r][new_c]
-                        # puts "Can combine after updating"
+                    if new_c < $l - 1 && !merged[r][new_c+1] && $grid[r][new_c+1] == $grid[r][new_c]
                         $grid[r][new_c+1] *= 2
                         $grid[r][new_c] = nil
+                        merged[r][new_c+1] = true
                     end
-                elsif c < $l - 1 && $grid[r][c+1] == $grid[r][c]
-                    # puts "Can combine"
+                elsif c < $l - 1 && !merged[r][c+1] && $grid[r][c+1] == $grid[r][c]
                     $grid[r][c+1] *= 2
                     $grid[r][c] = nil
                     $valid_move = true
-                    # display()
+                    merged[r][c+1] = true
                 end
             end
         end
@@ -186,40 +154,32 @@ def right
 end
 
 def left
+    merged = Array.new($l) { Array.new($l, false) }
     for r in 0...$l
         for c in 1...$l
             if $grid[r][c] != nil
-                # puts "Cell: " + r.to_s + ", " + c.to_s
-                # if cell to the left is empty, shift left
                 new_c = -1
                 for i in 1..c
-                    # print "Cell left: " + r.to_s + ", " + (c-i).to_s
                     if $grid[r][c-i] == nil
-                        # puts " is empty"
-                        # if block immediately left is empty, update new row to move to
                         new_c = c - i
                     else
-                        # puts " is not empty"
                         break
                     end
                 end
                 if new_c != -1
-                    # puts "new_c was updated"
                     $grid[r][new_c] = $grid[r][c]
                     $grid[r][c] = nil
                     $valid_move = true
-                    if new_c > 0 && $grid[r][new_c-1] == $grid[r][new_c]
-                        # puts "Can combine"
+                    if new_c > 0 && !merged[r][new_c-1] && $grid[r][new_c-1] == $grid[r][new_c]
                         $grid[r][new_c-1] *= 2
                         $grid[r][new_c] = nil
-                        # display()
+                        merged[r][new_c-1] = true
                     end
-                elsif c > 0 && $grid[r][c-1] == $grid[r][c]
-                    # puts "Can combine"
+                elsif c > 0 && !merged[r][c-1] && $grid[r][c-1] == $grid[r][c]
                     $grid[r][c-1] *= 2
                     $grid[r][c] = nil
                     $valid_move = true
-                    # display()
+                    merged[r][c-1] = true
                 end
             end
         end
@@ -276,15 +236,13 @@ def calculate_spaces
 end
 
 def new_block
-    puts "New block"
+    return if full?()
     rand_r = nil
     rand_c = nil
-    if !full?()
-        loop do
-            rand_r = rand($l)
-            rand_c = rand($l)
-            break if $grid[rand_r][rand_c] == nil
-        end
+    loop do
+        rand_r = rand($l)
+        rand_c = rand($l)
+        break if $grid[rand_r][rand_c] == nil
     end
     if rand() > 0.7
         $grid[rand_r][rand_c] = 4
@@ -294,17 +252,17 @@ def new_block
 end
 
 def game_over?
-    # overly simplified
     for r in 0...$l
         for c in 0...$l
             v = $grid[r][c]
-            if v != nil
-                if r > 0 && v == $grid[r-1][c] \
-                    || r < $l - 1 && v != $grid[r+1][c] \
-                    || c > 0 && v == $grid[r][c-1] \
-                    || c < $l - 1 && v != $grid[r][c+1]
-                    return false
-                end
+            if v == nil
+                return false
+            end
+            if r > 0 && v == $grid[r-1][c] \
+                || r < $l - 1 && v == $grid[r+1][c] \
+                || c > 0 && v == $grid[r][c-1] \
+                || c < $l - 1 && v == $grid[r][c+1]
+                return false
             end
         end
     end


### PR DESCRIPTION
- Remove redundant full?() check from game loop; game_over?() now handles
  all end conditions including empty cells and possible merges
- Fix game_over?() using != instead of == for two adjacency checks, which
  caused it to almost never report game over correctly
- Fix game_over?() to also return false when any cell is nil (moves possible)
- Add merged[][] tracking to all four move functions to prevent a tile from
  being merged more than once per move
- Replace removed Fixnum class with Integer for Ruby 2.4+ compatibility
- Remove dead code after game loop; replace with "Game over!" message
- Fix new_block() crash on full grid by returning early instead of assigning
  to nil coordinates
- Remove stray display() call mid-move inside up()
- Remove leftover debug puts "New block" from new_block()

https://claude.ai/code/session_01PTPTEjR4v8wE1Z75izZhyx