### PR TITLE
Refactor to idiomatic Ruby and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # 2048
+
+A terminal implementation of the [2048](https://en.wikipedia.org/wiki/2048_(video_game)) sliding tile puzzle, written in Ruby.
+
+## How to play
+
+```
+ruby main.rb
+```
+
+You will be prompted for a grid size (the standard game uses 4). On each turn, slide all tiles in one direction using the WASD keys:
+
+| Key | Direction |
+|-----|-----------|
+| `W` | Up        |
+| `A` | Left      |
+| `S` | Down      |
+| `D` | Right     |
+
+When two tiles with the same number collide, they merge into one tile with their sum. A new tile (2 or 4) is placed on the board after every valid move. The game ends when the board is full and no merges are possible.
+
+## Requirements
+
+- Ruby 3.3.6 (see `.ruby-version`)
+
+No gems required.
+
+## Running the tests
+
+```
+ruby test_game.rb
+```
+
+The test suite uses Ruby's built-in Minitest library — no installation needed.
+
+```
+45 runs, 162 assertions, 0 failures, 0 errors, 0 skips
+```
+
+## Project structure
+
+```
+main.rb        # Game logic (Game2048 class)
+test_game.rb   # Minitest test suite
+.ruby-version  # Pins Ruby version to 3.3.6
+```

--- a/main.rb
+++ b/main.rb
@@ -1,272 +1,156 @@
-def play
+class Game2048
+  attr_reader :size, :valid_move
+  attr_accessor :grid
+
+  def initialize(size: nil)
+    return unless size
+
+    @size = size
+    @grid = Array.new(@size) { Array.new(@size) }
+    @valid_move = false
+  end
+
+  def play
     puts "---- 2048 ----"
     print "Enter grid length: "
-    begin
-        $l = Integer(gets.chomp)
-    rescue
-        print "Please enter an integer number: "
-        retry
-    end
+    @size = prompt_size
+    @grid = Array.new(@size) { Array.new(@size) }
+    @valid_move = false
+    place_tile
+    display
 
-    $grid = Array.new($l) { Array.new($l) }
-    new_block()
-    display()
-
-    while !game_over?()
-        $valid_move = false
-        print "Up, Down, Right or Left? "
-        input = gets.chomp
-        move(input.upcase)
-        if $valid_move
-            new_block()
-        else
-            puts "Invalid move."
-        end
-        display()
+    until game_over?
+      @valid_move = false
+      print "W/A/S/D? "
+      move(gets.chomp.upcase)
+      if @valid_move
+        place_tile
+      else
+        puts "Invalid move."
+      end
+      display
     end
 
     puts "Game over!"
-end
+  end
 
-def full?
-    $grid.each {|x| x.each {|y| return false if y == nil}}
-    return true
-end
+  def full?
+    @grid.all? { |row| row.none?(&:nil?) }
+  end
 
-def move(input)
+  def game_over?
+    @grid.each_with_index do |row, r|
+      row.each_with_index do |v, c|
+        return false if v.nil?
+        return false if r > 0 && v == @grid[r - 1][c]
+        return false if r < @size - 1 && v == @grid[r + 1][c]
+        return false if c > 0 && v == @grid[r][c - 1]
+        return false if c < @size - 1 && v == @grid[r][c + 1]
+      end
+    end
+    true
+  end
+
+  def move(input)
     case input
-    when "W"
-        up()
-    when "A"
-        left()
-    when "S"
-        down()
-    when "D"
-        right()
-    when Integer
-        print "You entered a number. Choose a direction (W,A,S,D): "
-        input = gets.chomp
-        move(input.upcase)
-    when String
-        print "Use W, A, S, or D: "
-        input = gets.chomp
-        move(input.upcase)
-    end
-end
-
-def up
-    merged = Array.new($l) { Array.new($l, false) }
-    for r in 1...$l
-        for c in 0...$l
-            if $grid[r][c] != nil
-                new_r = -1
-                for i in 1..r
-                    if $grid[r-i][c] == nil
-                        new_r = r - i
-                    else
-                        break
-                    end
-                end
-                if new_r != -1
-                    $grid[new_r][c] = $grid[r][c]
-                    $grid[r][c] = nil
-                    $valid_move = true
-                    if new_r > 0 && !merged[new_r-1][c] && $grid[new_r-1][c] == $grid[new_r][c]
-                        $grid[new_r-1][c] *= 2
-                        $grid[new_r][c] = nil
-                        merged[new_r-1][c] = true
-                    end
-                elsif r > 0 && !merged[r-1][c] && $grid[r-1][c] == $grid[r][c]
-                    $grid[r-1][c] *= 2
-                    $grid[r][c] = nil
-                    $valid_move = true
-                    merged[r-1][c] = true
-                end
-            end
-        end
-    end
-end
-
-def down
-    merged = Array.new($l) { Array.new($l, false) }
-    for r in ($l-2).downto(0)
-        for c in 0...$l
-            if $grid[r][c] != nil
-                new_r = -1
-                for i in 1...($l-r)
-                    if $grid[r+i][c] == nil
-                        new_r = r + i
-                    else
-                        break
-                    end
-                end
-                if new_r != -1
-                    $grid[new_r][c] = $grid[r][c]
-                    $grid[r][c] = nil
-                    $valid_move = true
-                    if new_r < $l - 1 && !merged[new_r+1][c] && $grid[new_r+1][c] == $grid[new_r][c]
-                        $grid[new_r+1][c] *= 2
-                        $grid[new_r][c] = nil
-                        merged[new_r+1][c] = true
-                    end
-                elsif r < $l - 1 && !merged[r+1][c] && $grid[r+1][c] == $grid[r][c]
-                    $grid[r+1][c] *= 2
-                    $grid[r][c] = nil
-                    $valid_move = true
-                    merged[r+1][c] = true
-                end
-            end
-        end
-    end
-end
-
-def right
-    merged = Array.new($l) { Array.new($l, false) }
-    for r in 0...$l
-        for c in ($l-2).downto(0)
-            if $grid[r][c] != nil
-                new_c = -1
-                for i in 1...($l-c)
-                    if $grid[r][c+i] == nil
-                        new_c = c + i
-                    else
-                        break
-                    end
-                end
-                if new_c != -1
-                    $grid[r][new_c] = $grid[r][c]
-                    $grid[r][c] = nil
-                    $valid_move = true
-                    if new_c < $l - 1 && !merged[r][new_c+1] && $grid[r][new_c+1] == $grid[r][new_c]
-                        $grid[r][new_c+1] *= 2
-                        $grid[r][new_c] = nil
-                        merged[r][new_c+1] = true
-                    end
-                elsif c < $l - 1 && !merged[r][c+1] && $grid[r][c+1] == $grid[r][c]
-                    $grid[r][c+1] *= 2
-                    $grid[r][c] = nil
-                    $valid_move = true
-                    merged[r][c+1] = true
-                end
-            end
-        end
-    end
-end
-
-def left
-    merged = Array.new($l) { Array.new($l, false) }
-    for r in 0...$l
-        for c in 1...$l
-            if $grid[r][c] != nil
-                new_c = -1
-                for i in 1..c
-                    if $grid[r][c-i] == nil
-                        new_c = c - i
-                    else
-                        break
-                    end
-                end
-                if new_c != -1
-                    $grid[r][new_c] = $grid[r][c]
-                    $grid[r][c] = nil
-                    $valid_move = true
-                    if new_c > 0 && !merged[r][new_c-1] && $grid[r][new_c-1] == $grid[r][new_c]
-                        $grid[r][new_c-1] *= 2
-                        $grid[r][new_c] = nil
-                        merged[r][new_c-1] = true
-                    end
-                elsif c > 0 && !merged[r][c-1] && $grid[r][c-1] == $grid[r][c]
-                    $grid[r][c-1] *= 2
-                    $grid[r][c] = nil
-                    $valid_move = true
-                    merged[r][c-1] = true
-                end
-            end
-        end
-    end
-end
-
-def display
-    req_space = calculate_spaces()
-    for i in 0...$l
-        for j in 0...$l
-            print " "
-            for _ in 0...req_space
-                print "-"
-            end
-        end
-        puts
-        print "|"
-        for j in 0...$l
-            v = $grid[i][j]
-            if v == nil
-                v = ""
-                for _ in 0...req_space
-                    v += " "
-                end
-            end
-            v = v.to_s
-            for _ in 0...(req_space-v.length)
-                print " "
-            end
-            print v.to_s + "|"
-        end
-        puts
-    end
-    for j in 0...$l
-        print " "
-        for _ in 0...req_space
-            print "-"
-        end
-    end
-    puts
-end
-
-def calculate_spaces
-    max = 1
-    for r in 0...$l
-        for c in 0...$l
-            len = $grid[r][c].to_s.length
-            if len > max
-                max = len
-            end
-        end
-    end
-    return max
-end
-
-def new_block
-    return if full?()
-    rand_r = nil
-    rand_c = nil
-    loop do
-        rand_r = rand($l)
-        rand_c = rand($l)
-        break if $grid[rand_r][rand_c] == nil
-    end
-    if rand() > 0.7
-        $grid[rand_r][rand_c] = 4
+    when "W" then up
+    when "A" then left
+    when "S" then down
+    when "D" then right
     else
-        $grid[rand_r][rand_c] = 2
+      print "Use W, A, S, or D: "
+      move(gets.chomp.upcase)
     end
+  end
+
+  def up
+    @size.times do |c|
+      line = @size.times.map { |r| @grid[r][c] }
+      new_line, moved = slide_line(line)
+      @size.times { |r| @grid[r][c] = new_line[r] }
+      @valid_move = true if moved
+    end
+  end
+
+  def down
+    @size.times do |c|
+      line = @size.times.map { |r| @grid[r][c] }.reverse
+      new_line, moved = slide_line(line)
+      new_line.reverse!
+      @size.times { |r| @grid[r][c] = new_line[r] }
+      @valid_move = true if moved
+    end
+  end
+
+  def left
+    @size.times do |r|
+      new_line, moved = slide_line(@grid[r].dup)
+      @grid[r] = new_line
+      @valid_move = true if moved
+    end
+  end
+
+  def right
+    @size.times do |r|
+      new_line, moved = slide_line(@grid[r].reverse)
+      @grid[r] = new_line.reverse
+      @valid_move = true if moved
+    end
+  end
+
+  def place_tile
+    return if full?
+
+    loop do
+      r, c = rand(@size), rand(@size)
+      next unless @grid[r][c].nil?
+
+      @grid[r][c] = rand < 0.3 ? 4 : 2
+      break
+    end
+  end
+
+  def display
+    width = column_width
+    separator = (" " + "-" * width) * @size
+    @grid.each do |row|
+      puts separator
+      puts "|" + row.map { |v| v.to_s.rjust(width) }.join("|") + "|"
+    end
+    puts separator
+  end
+
+  def column_width
+    @grid.flatten.compact.map { |v| v.to_s.length }.max || 1
+  end
+
+  private
+
+  def prompt_size
+    Integer(gets.chomp)
+  rescue ArgumentError
+    print "Please enter an integer: "
+    retry
+  end
+
+  # Slides all non-nil values in +line+ toward index 0, merging equal
+  # adjacent tiles once each. Returns [new_line, moved].
+  def slide_line(line)
+    tiles = line.compact
+    merged = []
+    i = 0
+    while i < tiles.size
+      if i + 1 < tiles.size && tiles[i] == tiles[i + 1]
+        merged << tiles[i] * 2
+        i += 2
+      else
+        merged << tiles[i]
+        i += 1
+      end
+    end
+    new_line = merged + Array.new(line.size - merged.size)
+    [new_line, new_line != line]
+  end
 end
 
-def game_over?
-    for r in 0...$l
-        for c in 0...$l
-            v = $grid[r][c]
-            if v == nil
-                return false
-            end
-            if r > 0 && v == $grid[r-1][c] \
-                || r < $l - 1 && v == $grid[r+1][c] \
-                || c > 0 && v == $grid[r][c-1] \
-                || c < $l - 1 && v == $grid[r][c+1]
-                return false
-            end
-        end
-    end
-    return true
-end
-
-play()
+Game2048.new.play if __FILE__ == $0

--- a/test_game.rb
+++ b/test_game.rb
@@ -1,399 +1,394 @@
 require 'minitest/autorun'
-
-# Load game functions without triggering play()
-eval(File.read(File.join(__dir__, 'main.rb')).sub(/\nplay\(\)\n?$/, ''))
+require_relative 'main'
 
 class Test2048 < Minitest::Test
   def setup
-    $l = 4
-    $grid = Array.new($l) { Array.new($l) }
-    $valid_move = false
+    @game = Game2048.new(size: 4)
   end
 
-  # Sets $grid and $l from a 2-D array literal, e.g. [[2,nil],[nil,4]]
+  # Sets the grid (and size if different) from a 2-D array literal.
   def set_grid(rows)
-    $l = rows.size
-    $grid = rows.map(&:dup)
+    @game.instance_variable_set(:@size, rows.size)
+    @game.grid = rows.map(&:dup)
   end
 
-  # Returns the values in column c from top to bottom
+  # Returns all values in column c from top to bottom.
   def col(c)
-    (0...$l).map { |r| $grid[r][c] }
+    (0...@game.size).map { |r| @game.grid[r][c] }
   end
 
   # ── full? ──────────────────────────────────────────────────────────────────
 
   def test_full_empty_grid
-    refute full?
+    refute @game.full?
   end
 
   def test_full_one_tile
-    $grid[0][0] = 2
-    refute full?
+    @game.grid[0][0] = 2
+    refute @game.full?
   end
 
   def test_full_one_nil_remaining
-    $grid = Array.new($l) { Array.new($l, 2) }
-    $grid[$l-1][$l-1] = nil
-    refute full?
+    @game.grid = Array.new(@game.size) { Array.new(@game.size, 2) }
+    @game.grid[@game.size - 1][@game.size - 1] = nil
+    refute @game.full?
   end
 
   def test_full_completely_filled
-    $grid = Array.new($l) { Array.new($l, 2) }
-    assert full?
+    @game.grid = Array.new(@game.size) { Array.new(@game.size, 2) }
+    assert @game.full?
   end
 
   # ── game_over? ─────────────────────────────────────────────────────────────
 
   def test_game_over_empty_grid
-    refute game_over?
+    refute @game.game_over?
   end
 
   def test_game_over_single_tile
-    $grid[0][0] = 2
-    refute game_over?
+    @game.grid[0][0] = 2
+    refute @game.game_over?
   end
 
   def test_game_over_full_with_horizontal_merge_available
     val = 2
-    $grid.each_with_index { |row, r| row.each_with_index { |_, c| $grid[r][c] = val; val += 2 } }
-    $grid[0][0] = $grid[0][1]   # two equal neighbours in a row
-    refute game_over?
+    @game.grid.each_with_index { |row, r| row.each_with_index { |_, c| @game.grid[r][c] = val; val += 2 } }
+    @game.grid[0][0] = @game.grid[0][1]
+    refute @game.game_over?
   end
 
   def test_game_over_full_with_vertical_merge_available
     val = 2
-    $grid.each_with_index { |row, r| row.each_with_index { |_, c| $grid[r][c] = val; val += 2 } }
-    $grid[0][0] = $grid[1][0]   # two equal neighbours in a column
-    refute game_over?
+    @game.grid.each_with_index { |row, r| row.each_with_index { |_, c| @game.grid[r][c] = val; val += 2 } }
+    @game.grid[0][0] = @game.grid[1][0]
+    refute @game.game_over?
   end
 
   def test_game_over_true_when_full_and_no_merges
-    # Fill with all distinct values so no two adjacent cells are equal
     val = 2
-    $grid.each_with_index { |row, r| row.each_with_index { |_, c| $grid[r][c] = val; val += 2 } }
-    assert game_over?
+    @game.grid.each_with_index { |row, r| row.each_with_index { |_, c| @game.grid[r][c] = val; val += 2 } }
+    assert @game.game_over?
   end
 
   # ── up ─────────────────────────────────────────────────────────────────────
 
   def test_up_shifts_lone_tile_to_top
-    set_grid([[nil,nil,nil,nil],
-              [2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    up
-    assert_equal 2, $grid[0][0]
-    assert_nil $grid[1][0]
+    set_grid([[nil, nil, nil, nil],
+              [2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.up
+    assert_equal 2, @game.grid[0][0]
+    assert_nil @game.grid[1][0]
   end
 
   def test_up_sets_valid_move_on_shift
-    set_grid([[nil,nil,nil,nil],
-              [2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    up
-    assert $valid_move
+    set_grid([[nil, nil, nil, nil],
+              [2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.up
+    assert @game.valid_move
   end
 
   def test_up_no_valid_move_when_already_packed
-    set_grid([[2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    up
-    refute $valid_move
+    set_grid([[2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.up
+    refute @game.valid_move
   end
 
   def test_up_merges_adjacent_equal_tiles
-    set_grid([[2,  nil,nil,nil],
-              [2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    up
-    assert_equal 4, $grid[0][0]
-    assert_nil $grid[1][0]
+    set_grid([[2,   nil, nil, nil],
+              [2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.up
+    assert_equal 4, @game.grid[0][0]
+    assert_nil @game.grid[1][0]
   end
 
   def test_up_merges_equal_tiles_across_gap
-    set_grid([[2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [2,  nil,nil,nil],
-              [nil,nil,nil,nil]])
-    up
-    assert_equal 4, $grid[0][0]
-    assert_nil $grid[1][0]
-    assert_nil $grid[2][0]
+    set_grid([[2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [2,   nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.up
+    assert_equal 4, @game.grid[0][0]
+    assert_nil @game.grid[1][0]
+    assert_nil @game.grid[2][0]
   end
 
   def test_up_no_double_merge
-    set_grid([[2,nil,nil,nil],
-              [2,nil,nil,nil],
-              [2,nil,nil,nil],
-              [2,nil,nil,nil]])
-    up
+    set_grid([[2, nil, nil, nil],
+              [2, nil, nil, nil],
+              [2, nil, nil, nil],
+              [2, nil, nil, nil]])
+    @game.up
     assert_equal [4, 4, nil, nil], col(0)
   end
 
   def test_up_does_not_merge_different_values
-    set_grid([[2,  nil,nil,nil],
-              [4,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    up
-    assert_equal 2, $grid[0][0]
-    assert_equal 4, $grid[1][0]
+    set_grid([[2,   nil, nil, nil],
+              [4,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.up
+    assert_equal 2, @game.grid[0][0]
+    assert_equal 4, @game.grid[1][0]
   end
 
   def test_up_handles_multiple_columns_independently
-    set_grid([[nil,nil,nil,nil],
-              [2,  4,  nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    up
-    assert_equal 2, $grid[0][0]
-    assert_equal 4, $grid[0][1]
+    set_grid([[nil, nil, nil, nil],
+              [2,   4,   nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.up
+    assert_equal 2, @game.grid[0][0]
+    assert_equal 4, @game.grid[0][1]
   end
 
   # ── down ───────────────────────────────────────────────────────────────────
 
   def test_down_shifts_lone_tile_to_bottom
-    set_grid([[2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    down
-    assert_equal 2, $grid[3][0]
-    assert_nil $grid[0][0]
+    set_grid([[2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.down
+    assert_equal 2, @game.grid[3][0]
+    assert_nil @game.grid[0][0]
   end
 
   def test_down_sets_valid_move
-    set_grid([[2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    down
-    assert $valid_move
+    set_grid([[2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.down
+    assert @game.valid_move
   end
 
   def test_down_merges_adjacent_equal_tiles
-    set_grid([[nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [2,  nil,nil,nil],
-              [2,  nil,nil,nil]])
-    down
-    assert_equal 4, $grid[3][0]
-    assert_nil $grid[2][0]
+    set_grid([[nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [2,   nil, nil, nil],
+              [2,   nil, nil, nil]])
+    @game.down
+    assert_equal 4, @game.grid[3][0]
+    assert_nil @game.grid[2][0]
   end
 
   def test_down_no_double_merge
-    set_grid([[2,nil,nil,nil],
-              [2,nil,nil,nil],
-              [2,nil,nil,nil],
-              [2,nil,nil,nil]])
-    down
+    set_grid([[2, nil, nil, nil],
+              [2, nil, nil, nil],
+              [2, nil, nil, nil],
+              [2, nil, nil, nil]])
+    @game.down
     assert_equal [nil, nil, 4, 4], col(0)
   end
 
   def test_down_merges_equal_tiles_across_gap
-    set_grid([[nil,nil,nil,nil],
-              [2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [2,  nil,nil,nil]])
-    down
-    assert_equal 4, $grid[3][0]
-    assert_nil $grid[2][0]
-    assert_nil $grid[1][0]
+    set_grid([[nil, nil, nil, nil],
+              [2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [2,   nil, nil, nil]])
+    @game.down
+    assert_equal 4, @game.grid[3][0]
+    assert_nil @game.grid[2][0]
+    assert_nil @game.grid[1][0]
   end
 
   # ── left ───────────────────────────────────────────────────────────────────
 
   def test_left_shifts_lone_tile_to_leftmost
-    set_grid([[nil,nil,2,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    left
-    assert_equal 2, $grid[0][0]
-    assert_nil $grid[0][2]
+    set_grid([[nil, nil, 2,   nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    assert_equal 2, @game.grid[0][0]
+    assert_nil @game.grid[0][2]
   end
 
   def test_left_sets_valid_move
-    set_grid([[nil,2,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    left
-    assert $valid_move
+    set_grid([[nil, 2,   nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    assert @game.valid_move
   end
 
   def test_left_no_valid_move_when_already_packed
-    set_grid([[2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    left
-    refute $valid_move
+    set_grid([[2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    refute @game.valid_move
   end
 
   def test_left_merges_adjacent_equal_tiles
-    set_grid([[2,2,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    left
-    assert_equal 4, $grid[0][0]
-    assert_nil $grid[0][1]
+    set_grid([[2,   2,   nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    assert_equal 4, @game.grid[0][0]
+    assert_nil @game.grid[0][1]
   end
 
   def test_left_merges_equal_tiles_across_gap
-    set_grid([[2,nil,2,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    left
-    assert_equal 4, $grid[0][0]
-    assert_nil $grid[0][1]
-    assert_nil $grid[0][2]
+    set_grid([[2,   nil, 2,   nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    assert_equal 4, @game.grid[0][0]
+    assert_nil @game.grid[0][1]
+    assert_nil @game.grid[0][2]
   end
 
   def test_left_no_double_merge
-    set_grid([[2,2,2,2],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    left
-    assert_equal [4, 4, nil, nil], $grid[0]
+    set_grid([[2, 2, 2, 2],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    assert_equal [4, 4, nil, nil], @game.grid[0]
   end
 
   def test_left_does_not_merge_different_values
-    set_grid([[2,4,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    left
-    assert_equal 2, $grid[0][0]
-    assert_equal 4, $grid[0][1]
+    set_grid([[2,   4,   nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    assert_equal 2, @game.grid[0][0]
+    assert_equal 4, @game.grid[0][1]
   end
 
   # ── right ──────────────────────────────────────────────────────────────────
 
   def test_right_shifts_lone_tile_to_rightmost
-    set_grid([[2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    right
-    assert_equal 2, $grid[0][3]
-    assert_nil $grid[0][0]
+    set_grid([[2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.right
+    assert_equal 2, @game.grid[0][3]
+    assert_nil @game.grid[0][0]
   end
 
   def test_right_sets_valid_move
-    set_grid([[2,  nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    right
-    assert $valid_move
+    set_grid([[2,   nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.right
+    assert @game.valid_move
   end
 
   def test_right_merges_adjacent_equal_tiles
-    set_grid([[nil,nil,2,2],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    right
-    assert_equal 4, $grid[0][3]
-    assert_nil $grid[0][2]
+    set_grid([[nil, nil, 2, 2],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.right
+    assert_equal 4, @game.grid[0][3]
+    assert_nil @game.grid[0][2]
   end
 
   def test_right_merges_equal_tiles_across_gap
-    set_grid([[nil,2,nil,2],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    right
-    assert_equal 4, $grid[0][3]
-    assert_nil $grid[0][2]
-    assert_nil $grid[0][1]
+    set_grid([[nil, 2,   nil, 2],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.right
+    assert_equal 4, @game.grid[0][3]
+    assert_nil @game.grid[0][2]
+    assert_nil @game.grid[0][1]
   end
 
   def test_right_no_double_merge
-    set_grid([[2,2,2,2],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil],
-              [nil,nil,nil,nil]])
-    right
-    assert_equal [nil, nil, 4, 4], $grid[0]
+    set_grid([[2, 2, 2, 2],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.right
+    assert_equal [nil, nil, 4, 4], @game.grid[0]
   end
 
-  # ── new_block ──────────────────────────────────────────────────────────────
+  # ── place_tile ─────────────────────────────────────────────────────────────
 
-  def test_new_block_places_one_tile_on_empty_grid
-    new_block
-    assert_equal 1, $grid.flatten.compact.size
+  def test_place_tile_adds_one_tile_to_empty_grid
+    @game.place_tile
+    assert_equal 1, @game.grid.flatten.compact.size
   end
 
-  def test_new_block_places_2_or_4
+  def test_place_tile_value_is_2_or_4
     100.times do
-      $grid = Array.new($l) { Array.new($l) }
-      new_block
-      val = $grid.flatten.compact.first
+      @game.grid = Array.new(@game.size) { Array.new(@game.size) }
+      @game.place_tile
+      val = @game.grid.flatten.compact.first
       assert [2, 4].include?(val), "Expected 2 or 4, got #{val}"
     end
   end
 
-  def test_new_block_places_tile_in_empty_cell
-    $grid = Array.new($l) { Array.new($l, 2) }
-    $grid[1][2] = nil
-    new_block
-    refute_nil $grid[1][2]
+  def test_place_tile_targets_an_empty_cell
+    @game.grid = Array.new(@game.size) { Array.new(@game.size, 2) }
+    @game.grid[1][2] = nil
+    @game.place_tile
+    refute_nil @game.grid[1][2]
   end
 
-  def test_new_block_does_nothing_when_full
-    $grid = Array.new($l) { Array.new($l, 2) }
-    snapshot = $grid.map(&:dup)
-    new_block
-    assert_equal snapshot, $grid
+  def test_place_tile_does_nothing_when_full
+    @game.grid = Array.new(@game.size) { Array.new(@game.size, 2) }
+    snapshot = @game.grid.map(&:dup)
+    @game.place_tile
+    assert_equal snapshot, @game.grid
   end
 
-  # ── calculate_spaces ───────────────────────────────────────────────────────
+  # ── column_width ───────────────────────────────────────────────────────────
 
-  def test_calculate_spaces_empty_grid_returns_one
-    assert_equal 1, calculate_spaces
+  def test_column_width_empty_grid_returns_one
+    assert_equal 1, @game.column_width
   end
 
-  def test_calculate_spaces_single_digit_value
-    $grid[0][0] = 2
-    assert_equal 1, calculate_spaces
+  def test_column_width_single_digit_value
+    @game.grid[0][0] = 2
+    assert_equal 1, @game.column_width
   end
 
-  def test_calculate_spaces_four_digit_value
-    $grid[0][0] = 2048
-    assert_equal 4, calculate_spaces
+  def test_column_width_four_digit_value
+    @game.grid[0][0] = 2048
+    assert_equal 4, @game.column_width
   end
 
-  def test_calculate_spaces_uses_largest_value
-    $grid[0][0] = 8
-    $grid[1][1] = 1024
-    assert_equal 4, calculate_spaces
+  def test_column_width_uses_largest_value
+    @game.grid[0][0] = 8
+    @game.grid[1][1] = 1024
+    assert_equal 4, @game.column_width
   end
 
   # ── display (smoke) ────────────────────────────────────────────────────────
 
   def test_display_does_not_crash_on_empty_grid
-    capture_io { display }
+    capture_io { @game.display }
   end
 
   def test_display_does_not_crash_with_tiles
-    $grid[0][0] = 2
-    $grid[1][1] = 1024
-    capture_io { display }
+    @game.grid[0][0] = 2
+    @game.grid[1][1] = 1024
+    capture_io { @game.display }
   end
 
   def test_display_contains_tile_values
-    $grid[0][0] = 512
-    out, = capture_io { display }
-    assert_includes out, '512'
+    @game.grid[0][0] = 512
+    out, = capture_io { @game.display }
+    assert_includes out, "512"
   end
 end


### PR DESCRIPTION
## Summary

- **Refactor to `Game2048` class**: replaced `$l`/`$grid`/`$valid_move` globals with instance variables; extracted a `slide_line` private method that eliminates ~200 lines of duplicated logic across `up`/`down`/`left`/`right`; replaced `for` loops with idiomatic iterators; `== nil` → `.nil?`; bare `rescue` → `rescue ArgumentError`; renamed `new_block` → `place_tile` and `calculate_spaces` → `column_width`; added `if __FILE__ == $0` entry-point guard
- **Updated tests**: dropped `eval` in favour of `require_relative`; all tests updated to instantiate `Game2048` directly and access state via public readers
- **README**: added gameplay instructions, controls table, requirements, test usage, and project structure

## Test plan

- [ ] `ruby test_game.rb` — 45 runs, 0 failures, 0 errors
- [ ] `ruby -wc main.rb` — `Syntax OK`, no warnings
- [ ] `ruby main.rb` — game starts, WASD controls work, game over message appears when no moves remain