### PR TITLE
Add Charm Ruby TUI (lipgloss tiles + Bubble Tea game loop)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+ruby "3.3.6"
+
+gem "bubbletea"
+gem "lipgloss"
+gem "tty-prompt"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # 2048
 
-A terminal implementation of the [2048](https://en.wikipedia.org/wiki/2048_(video_game)) sliding tile puzzle, written in Ruby.
+A terminal implementation of the [2048](https://en.wikipedia.org/wiki/2048_(video_game)) sliding tile puzzle, written in Ruby with a full-colour TUI powered by [bubbletea-ruby](https://github.com/marcoroth/bubbletea-ruby) and [lipgloss-ruby](https://github.com/marcoroth/lipgloss-ruby).
+
+## Requirements
+
+- Ruby 3.3.6 (see `.ruby-version`)
+- [Bundler](https://bundler.io/)
+
+## Setup
+
+```
+bundle install
+```
 
 ## How to play
 
@@ -8,7 +19,9 @@ A terminal implementation of the [2048](https://en.wikipedia.org/wiki/2048_(vide
 ruby main.rb
 ```
 
-You will be prompted for a grid size (the standard game uses 4). On each turn, slide all tiles in one direction using the WASD keys:
+You will be prompted for a grid size (the standard game uses 4). If a saved game exists you will be offered the option to resume it instead.
+
+The board renders in the alternate screen buffer with the classic 2048 colour palette. Slide all tiles in one direction using the WASD keys:
 
 | Key | Direction |
 |-----|-----------|
@@ -17,30 +30,28 @@ You will be prompted for a grid size (the standard game uses 4). On each turn, s
 | `S` | Down      |
 | `D` | Right     |
 
-When two tiles with the same number collide, they merge into one tile with their sum. A new tile (2 or 4) is placed on the board after every valid move. The game ends when the board is full and no merges are possible.
+When two tiles with the same number collide they merge into one tile with their combined value and your score increases accordingly. A new tile (2 or 4) is placed on the board after every valid move. The game ends when the board is full and no merges are possible.
 
-## Requirements
-
-- Ruby 3.3.6 (see `.ruby-version`)
-
-No gems required.
+Press **Q** at any time to save and quit. Your board and score are written to `2048_save.json` and restored the next time you run the game.
 
 ## Running the tests
+
+The test suite exercises only the pure game logic and has no dependency on the TUI gems.
 
 ```
 ruby test_game.rb
 ```
 
-The test suite uses Ruby's built-in Minitest library — no installation needed.
-
 ```
-45 runs, 162 assertions, 0 failures, 0 errors, 0 skips
+54 runs, 174 assertions, 0 failures, 0 errors, 0 skips
 ```
 
 ## Project structure
 
 ```
-main.rb        # Game logic (Game2048 class)
-test_game.rb   # Minitest test suite
+game.rb        # Pure Game2048 logic (grid, moves, score, save/load)
+main.rb        # TUI entry point — GameTUI (Bubbletea::Model) + lipgloss rendering
+test_game.rb   # Minitest test suite (no TUI dependencies)
+Gemfile        # bubbletea, lipgloss, tty-prompt
 .ruby-version  # Pins Ruby version to 3.3.6
 ```

--- a/game.rb
+++ b/game.rb
@@ -1,0 +1,136 @@
+require 'json'
+
+SAVE_FILE = "2048_save.json"
+
+class Game2048
+  attr_reader :size, :score
+  attr_accessor :grid, :valid_move
+
+  def initialize(size: nil)
+    return unless size
+
+    @size       = size
+    @grid       = Array.new(@size) { Array.new(@size) }
+    @valid_move = false
+    @score      = 0
+  end
+
+  def full?
+    @grid.all? { |row| row.none?(&:nil?) }
+  end
+
+  def game_over?
+    @grid.each_with_index do |row, r|
+      row.each_with_index do |v, c|
+        return false if v.nil?
+        return false if r > 0              && v == @grid[r - 1][c]
+        return false if r < @size - 1     && v == @grid[r + 1][c]
+        return false if c > 0              && v == @grid[r][c - 1]
+        return false if c < @size - 1     && v == @grid[r][c + 1]
+      end
+    end
+    true
+  end
+
+  def up
+    @size.times do |c|
+      line = @size.times.map { |r| @grid[r][c] }
+      new_line, moved, delta = slide_line(line)
+      @size.times { |r| @grid[r][c] = new_line[r] }
+      @valid_move = true if moved
+      @score += delta
+    end
+  end
+
+  def down
+    @size.times do |c|
+      line = @size.times.map { |r| @grid[r][c] }.reverse
+      new_line, moved, delta = slide_line(line)
+      new_line.reverse!
+      @size.times { |r| @grid[r][c] = new_line[r] }
+      @valid_move = true if moved
+      @score += delta
+    end
+  end
+
+  def left
+    @size.times do |r|
+      new_line, moved, delta = slide_line(@grid[r].dup)
+      @grid[r] = new_line
+      @valid_move = true if moved
+      @score += delta
+    end
+  end
+
+  def right
+    @size.times do |r|
+      new_line, moved, delta = slide_line(@grid[r].reverse)
+      @grid[r] = new_line.reverse
+      @valid_move = true if moved
+      @score += delta
+    end
+  end
+
+  def place_tile
+    return if full?
+
+    loop do
+      r, c = rand(@size), rand(@size)
+      next unless @grid[r][c].nil?
+
+      @grid[r][c] = rand < 0.3 ? 4 : 2
+      break
+    end
+  end
+
+  # Plain-text render kept for non-TUI use and debugging.
+  def display
+    width = column_width
+    separator = (" " + "-" * width) * @size
+    @grid.each do |row|
+      puts separator
+      puts "|" + row.map { |v| v.to_s.rjust(width) }.join("|") + "|"
+    end
+    puts separator
+  end
+
+  def column_width
+    @grid.flatten.compact.map { |v| v.to_s.length }.max || 1
+  end
+
+  def save_game(path = SAVE_FILE)
+    File.write(path, JSON.generate({ "size" => @size, "grid" => @grid, "score" => @score }))
+  end
+
+  def load_game(path = SAVE_FILE)
+    data    = JSON.parse(File.read(path))
+    @size   = data["size"]
+    @grid   = data["grid"]
+    @score  = data["score"] || 0
+    @valid_move = false
+  end
+
+  private
+
+  # Slides all non-nil values in +line+ toward index 0, merging equal
+  # adjacent tiles once each. Returns [new_line, moved, score_delta].
+  def slide_line(line)
+    tiles       = line.compact
+    merged      = []
+    score_delta = 0
+    i = 0
+    while i < tiles.size
+      if i + 1 < tiles.size && tiles[i] == tiles[i + 1]
+        val = tiles[i] * 2
+        merged << val
+        score_delta += val
+        i += 2
+      else
+        merged << tiles[i]
+        i += 1
+      end
+    end
+    new_line = merged + Array.new(line.size - merged.size)
+    [new_line, new_line != line, score_delta]
+  end
+end

--- a/main.rb
+++ b/main.rb
@@ -1,193 +1,165 @@
-require 'json'
+require 'bubbletea'
+require 'lipgloss'
+require 'tty-prompt'
+require_relative 'game'
 
-SAVE_FILE = "2048_save.json"
+# Classic 2048 colour palette — foreground + background per tile value.
+TILE_COLORS = {
+  nil  => { fg: "#776e65", bg: "#cdc1b4" },
+  2    => { fg: "#776e65", bg: "#eee4da" },
+  4    => { fg: "#776e65", bg: "#ede0c8" },
+  8    => { fg: "#f9f6f2", bg: "#f2b179" },
+  16   => { fg: "#f9f6f2", bg: "#f59563" },
+  32   => { fg: "#f9f6f2", bg: "#f67c5f" },
+  64   => { fg: "#f9f6f2", bg: "#f65e3b" },
+  128  => { fg: "#f9f6f2", bg: "#edcf72" },
+  256  => { fg: "#f9f6f2", bg: "#edcc61" },
+  512  => { fg: "#f9f6f2", bg: "#edc850" },
+  1024 => { fg: "#f9f6f2", bg: "#edc53f" },
+  2048 => { fg: "#f9f6f2", bg: "#edc22e" },
+}.freeze
 
-class Game2048
-  attr_reader :size, :valid_move
-  attr_accessor :grid
+class GameTUI
+  include Bubbletea::Model
 
-  def initialize(size: nil)
-    return unless size
+  CELL_WIDTH  = 6   # interior character width of each tile
+  CELL_HEIGHT = 3   # interior line height of each tile
 
-    @size = size
-    @grid = Array.new(@size) { Array.new(@size) }
-    @valid_move = false
+  def initialize(game)
+    @game    = game
+    @message = nil
   end
 
-  def play
-    puts "---- 2048 ----"
-
-    if File.exist?(SAVE_FILE)
-      print "Saved game found. Load it? (Y/N): "
-      if gets.chomp.upcase == "Y"
-        load_game
-      else
-        start_new_game
-      end
-    else
-      start_new_game
-    end
-
-    display
-
-    until game_over?
-      @valid_move = false
-      print "W/A/S/D (or Q to save and quit)? "
-      input = gets.chomp.upcase
-      if input == "Q"
-        save_game
-        puts "Game saved to #{SAVE_FILE}. Goodbye!"
-        return
-      end
-      move(input)
-      if @valid_move
-        place_tile
-      else
-        puts "Invalid move."
-      end
-      display
-    end
-
-    puts "Game over!"
-    File.delete(SAVE_FILE) if File.exist?(SAVE_FILE)
+  def init
+    [self, Bubbletea.set_window_title("2048")]
   end
 
-  def save_game(path = SAVE_FILE)
-    File.write(path, JSON.generate({ "size" => @size, "grid" => @grid }))
-  end
-
-  def load_game(path = SAVE_FILE)
-    data = JSON.parse(File.read(path))
-    @size = data["size"]
-    @grid = data["grid"]
-    @valid_move = false
-  end
-
-  def full?
-    @grid.all? { |row| row.none?(&:nil?) }
-  end
-
-  def game_over?
-    @grid.each_with_index do |row, r|
-      row.each_with_index do |v, c|
-        return false if v.nil?
-        return false if r > 0 && v == @grid[r - 1][c]
-        return false if r < @size - 1 && v == @grid[r + 1][c]
-        return false if c > 0 && v == @grid[r][c - 1]
-        return false if c < @size - 1 && v == @grid[r][c + 1]
-      end
-    end
-    true
-  end
-
-  def move(input)
-    case input
-    when "W" then up
-    when "A" then left
-    when "S" then down
-    when "D" then right
-    else
-      print "Use W, A, S, or D: "
-      move(gets.chomp.upcase)
+  def update(msg)
+    case msg
+    when Bubbletea::KeyMessage then handle_key(msg.to_s)
+    else [self, nil]
     end
   end
 
-  def up
-    @size.times do |c|
-      line = @size.times.map { |r| @grid[r][c] }
-      new_line, moved = slide_line(line)
-      @size.times { |r| @grid[r][c] = new_line[r] }
-      @valid_move = true if moved
-    end
-  end
-
-  def down
-    @size.times do |c|
-      line = @size.times.map { |r| @grid[r][c] }.reverse
-      new_line, moved = slide_line(line)
-      new_line.reverse!
-      @size.times { |r| @grid[r][c] = new_line[r] }
-      @valid_move = true if moved
-    end
-  end
-
-  def left
-    @size.times do |r|
-      new_line, moved = slide_line(@grid[r].dup)
-      @grid[r] = new_line
-      @valid_move = true if moved
-    end
-  end
-
-  def right
-    @size.times do |r|
-      new_line, moved = slide_line(@grid[r].reverse)
-      @grid[r] = new_line.reverse
-      @valid_move = true if moved
-    end
-  end
-
-  def place_tile
-    return if full?
-
-    loop do
-      r, c = rand(@size), rand(@size)
-      next unless @grid[r][c].nil?
-
-      @grid[r][c] = rand < 0.3 ? 4 : 2
-      break
-    end
-  end
-
-  def display
-    width = column_width
-    separator = (" " + "-" * width) * @size
-    @grid.each do |row|
-      puts separator
-      puts "|" + row.map { |v| v.to_s.rjust(width) }.join("|") + "|"
-    end
-    puts separator
-  end
-
-  def column_width
-    @grid.flatten.compact.map { |v| v.to_s.length }.max || 1
+  def view
+    [header_view, "", grid_view, "", footer_view].join("\n")
   end
 
   private
 
-  def start_new_game
-    print "Enter grid length: "
-    @size = prompt_size
-    @grid = Array.new(@size) { Array.new(@size) }
-    @valid_move = false
-    place_tile
-  end
+  # ── key handling ────────────────────────────────────────────────────────────
 
-  def prompt_size
-    Integer(gets.chomp)
-  rescue ArgumentError
-    print "Please enter an integer: "
-    retry
-  end
-
-  # Slides all non-nil values in +line+ toward index 0, merging equal
-  # adjacent tiles once each. Returns [new_line, moved].
-  def slide_line(line)
-    tiles = line.compact
-    merged = []
-    i = 0
-    while i < tiles.size
-      if i + 1 < tiles.size && tiles[i] == tiles[i + 1]
-        merged << tiles[i] * 2
-        i += 2
-      else
-        merged << tiles[i]
-        i += 1
-      end
+  def handle_key(key)
+    if @game.game_over?
+      return [self, Bubbletea.quit] if key == "q" || key == "ctrl+c"
+      return [self, nil]
     end
-    new_line = merged + Array.new(line.size - merged.size)
-    [new_line, new_line != line]
+
+    case key
+    when "w" then apply_move(:up)
+    when "a" then apply_move(:left)
+    when "s" then apply_move(:down)
+    when "d" then apply_move(:right)
+    when "q", "ctrl+c"
+      @game.save_game
+      [self, Bubbletea.quit]
+    else
+      [self, nil]
+    end
+  end
+
+  def apply_move(direction)
+    @game.valid_move = false
+    @game.send(direction)
+    if @game.valid_move
+      @game.place_tile
+      @message = nil
+      File.delete(SAVE_FILE) if @game.game_over? && File.exist?(SAVE_FILE)
+    else
+      @message = "No tiles moved."
+    end
+    [self, nil]
+  end
+
+  # ── view helpers ────────────────────────────────────────────────────────────
+
+  def header_view
+    title = Lipgloss::Style.new
+      .bold(true)
+      .foreground("#f9f6f2")
+      .background("#776e65")
+      .padding(0, 2)
+      .render("2048")
+
+    score_label = Lipgloss::Style.new
+      .foreground("#776e65")
+      .render("Score: ")
+
+    score_value = Lipgloss::Style.new
+      .bold(true)
+      .foreground("#f65e3b")
+      .render(@game.score.to_s)
+
+    Lipgloss.join_horizontal(:center, title, "  ", score_label, score_value)
+  end
+
+  def grid_view
+    rows = @game.grid.map do |row|
+      cells = row.map { |v| render_tile(v) }
+      Lipgloss.join_horizontal(:top, *cells)
+    end
+    Lipgloss.join_vertical(:left, *rows)
+  end
+
+  def render_tile(value)
+    colors = TILE_COLORS[value] || TILE_COLORS[nil]
+    text   = value ? value.to_s : ""
+
+    Lipgloss::Style.new
+      .width(CELL_WIDTH)
+      .height(CELL_HEIGHT)
+      .align(:center, :center)
+      .bold(!value.nil?)
+      .foreground(colors[:fg])
+      .background(colors[:bg])
+      .render(text)
+  end
+
+  def footer_view
+    if @game.game_over?
+      Lipgloss::Style.new
+        .bold(true)
+        .foreground("#f65e3b")
+        .render("Game over!  Press Q to exit.")
+    else
+      hint = Lipgloss::Style.new.faint(true).render("W/A/S/D: move   Q: save & quit")
+      msg  = @message ? Lipgloss::Style.new.foreground("#f59563").render("   #{@message}") : ""
+      hint + msg
+    end
   end
 end
 
-Game2048.new.play if __FILE__ == $0
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+if __FILE__ == $0
+  unless Bubbletea.tty?
+    puts "Error: a TTY is required to run the TUI."
+    exit 1
+  end
+
+  prompt = TTY::Prompt.new
+
+  game =
+    if File.exist?(SAVE_FILE) && prompt.yes?("Saved game found. Load it?")
+      g = Game2048.new
+      g.load_game
+      g
+    else
+      size = prompt.ask("Grid size:", default: "4", convert: :int)
+      g = Game2048.new(size: size)
+      g.place_tile
+      g
+    end
+
+  Bubbletea.run(GameTUI.new(game), alt_screen: true)
+end

--- a/main.rb
+++ b/main.rb
@@ -1,3 +1,7 @@
+require 'json'
+
+SAVE_FILE = "2048_save.json"
+
 class Game2048
   attr_reader :size, :valid_move
   attr_accessor :grid
@@ -12,17 +16,30 @@ class Game2048
 
   def play
     puts "---- 2048 ----"
-    print "Enter grid length: "
-    @size = prompt_size
-    @grid = Array.new(@size) { Array.new(@size) }
-    @valid_move = false
-    place_tile
+
+    if File.exist?(SAVE_FILE)
+      print "Saved game found. Load it? (Y/N): "
+      if gets.chomp.upcase == "Y"
+        load_game
+      else
+        start_new_game
+      end
+    else
+      start_new_game
+    end
+
     display
 
     until game_over?
       @valid_move = false
-      print "W/A/S/D? "
-      move(gets.chomp.upcase)
+      print "W/A/S/D (or Q to save and quit)? "
+      input = gets.chomp.upcase
+      if input == "Q"
+        save_game
+        puts "Game saved to #{SAVE_FILE}. Goodbye!"
+        return
+      end
+      move(input)
       if @valid_move
         place_tile
       else
@@ -32,6 +49,18 @@ class Game2048
     end
 
     puts "Game over!"
+    File.delete(SAVE_FILE) if File.exist?(SAVE_FILE)
+  end
+
+  def save_game(path = SAVE_FILE)
+    File.write(path, JSON.generate({ "size" => @size, "grid" => @grid }))
+  end
+
+  def load_game(path = SAVE_FILE)
+    data = JSON.parse(File.read(path))
+    @size = data["size"]
+    @grid = data["grid"]
+    @valid_move = false
   end
 
   def full?
@@ -125,6 +154,14 @@ class Game2048
   end
 
   private
+
+  def start_new_game
+    print "Enter grid length: "
+    @size = prompt_size
+    @grid = Array.new(@size) { Array.new(@size) }
+    @valid_move = false
+    place_tile
+  end
 
   def prompt_size
     Integer(gets.chomp)

--- a/test_game.rb
+++ b/test_game.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
-require_relative 'main'
+require_relative 'game'
 
 class Test2048 < Minitest::Test
   def setup
@@ -374,6 +374,36 @@ class Test2048 < Minitest::Test
     assert_equal 4, @game.column_width
   end
 
+  # ── score ──────────────────────────────────────────────────────────────────
+
+  def test_score_starts_at_zero
+    assert_equal 0, @game.score
+  end
+
+  def test_score_increases_on_merge
+    set_grid([[2, 2, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    assert_equal 4, @game.score
+  end
+
+  def test_score_accumulates_across_merges
+    set_grid([[2, 2, 4, 4],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left
+    assert_equal 12, @game.score  # 4 + 8
+  end
+
+  def test_score_unaffected_by_non_merging_move
+    @game.grid[0][0] = 2
+    @game.left
+    assert_equal 0, @game.score
+  end
+
   # ── save_game / load_game ──────────────────────────────────────────────────
 
   def test_save_game_creates_file
@@ -393,8 +423,25 @@ class Test2048 < Minitest::Test
 
     other = Game2048.new(size: 4)
     other.load_game(path)
-    assert_equal @game.size, other.size
-    assert_equal @game.grid, other.grid
+    assert_equal @game.size,  other.size
+    assert_equal @game.grid,  other.grid
+    assert_equal @game.score, other.score
+  ensure
+    File.delete(path) if File.exist?(path)
+  end
+
+  def test_save_and_load_preserves_score
+    path = "/tmp/test_2048_save_#{$$}.json"
+    set_grid([[2, 2, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil],
+              [nil, nil, nil, nil]])
+    @game.left   # merges → score = 4
+    @game.save_game(path)
+
+    other = Game2048.new(size: 4)
+    other.load_game(path)
+    assert_equal 4, other.score
   ensure
     File.delete(path) if File.exist?(path)
   end

--- a/test_game.rb
+++ b/test_game.rb
@@ -374,6 +374,56 @@ class Test2048 < Minitest::Test
     assert_equal 4, @game.column_width
   end
 
+  # ── save_game / load_game ──────────────────────────────────────────────────
+
+  def test_save_game_creates_file
+    path = "/tmp/test_2048_save_#{$$}.json"
+    @game.grid[0][0] = 2
+    @game.save_game(path)
+    assert File.exist?(path)
+  ensure
+    File.delete(path) if File.exist?(path)
+  end
+
+  def test_save_and_load_round_trip
+    path = "/tmp/test_2048_save_#{$$}.json"
+    @game.grid[0][0] = 2
+    @game.grid[1][2] = 512
+    @game.save_game(path)
+
+    other = Game2048.new(size: 4)
+    other.load_game(path)
+    assert_equal @game.size, other.size
+    assert_equal @game.grid, other.grid
+  ensure
+    File.delete(path) if File.exist?(path)
+  end
+
+  def test_load_game_restores_size
+    path = "/tmp/test_2048_save_#{$$}.json"
+    game3 = Game2048.new(size: 3)
+    game3.grid[0][0] = 4
+    game3.save_game(path)
+
+    other = Game2048.new(size: 4)
+    other.load_game(path)
+    assert_equal 3, other.size
+  ensure
+    File.delete(path) if File.exist?(path)
+  end
+
+  def test_save_preserves_nil_cells
+    path = "/tmp/test_2048_save_#{$$}.json"
+    @game.grid[0][0] = 8
+    @game.save_game(path)
+    other = Game2048.new(size: 4)
+    other.load_game(path)
+    assert_nil other.grid[0][1]
+    assert_equal 8, other.grid[0][0]
+  ensure
+    File.delete(path) if File.exist?(path)
+  end
+
   # ── display (smoke) ────────────────────────────────────────────────────────
 
   def test_display_does_not_crash_on_empty_grid


### PR DESCRIPTION
Closes #3 (TUI enhancement)

## Summary

- **`game.rb`** — pure `Game2048` logic extracted from `main.rb`; now also tracks `@score` (incremented in `slide_line` on each merge) and exposes `attr_accessor :valid_move` so the TUI can reset it cleanly between moves
- **`main.rb`** — becomes the TUI entry point; `GameTUI` wraps `Game2048` in a `Bubbletea::Model` (model / update / view loop):
  - `lipgloss-ruby` renders each tile with the classic 2048 hex colour palette, 6×3 fixed-size cells, bold numerals, and a live score header
  - `tty-prompt` handles pre-game setup (grid size, save-file detection) before the Bubble Tea loop starts — keeps the proven prompt UX from the previous PR
  - `alt_screen: true` keeps the board in-place with no terminal scroll
  - W/A/S/D to move; Q saves and exits; game-over screen prompts Q to quit and cleans up the save file
- **`Gemfile`** — pins `bubbletea`, `lipgloss`, `tty-prompt`
- **`test_game.rb`** — updated to `require_relative 'game'`; 5 new score tests (starts at zero, increases on merge, accumulates, unaffected by shift-only move, round-trips through save/load); 54 total, 0 failures

## Test plan

- [ ] `bundle install`
- [ ] `ruby test_game.rb` — 54 runs, 0 failures, 0 errors
- [ ] `ruby -wc game.rb main.rb` — `Syntax OK`, no warnings
- [ ] `ruby main.rb` — TUI starts, coloured tiles render, score updates on merges, Q saves and exits, reloading the save restores score and board

https://claude.ai/code/session_01PTPTEjR4v8wE1Z75izZhyx