### PR TITLE
Add CC BY-NC 4.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2026 shingkid
+Copyright (c) 2026 Jane Seah
 
 This work is licensed under the Creative Commons Attribution-NonCommercial 4.0
 International License (CC BY-NC 4.0).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2026 shingkid
+
+This work is licensed under the Creative Commons Attribution-NonCommercial 4.0
+International License (CC BY-NC 4.0).
+
+You are free to:
+  - Share   — copy and redistribute the material in any medium or format
+  - Adapt   — remix, transform, and build upon the material
+
+Under the following terms:
+  - Attribution      — You must give appropriate credit, provide a link to the
+                       license, and indicate if changes were made.
+  - NonCommercial    — You may not use the material for commercial purposes.
+
+No additional restrictions — you may not apply legal terms or technological
+measures that legally restrict others from doing anything the license permits.
+
+Full license text: https://creativecommons.org/licenses/by-nc/4.0/legalcode
+
+-------------------------------------------------------------------------------
+
+This project is an independent Ruby reimplementation inspired by the original
+2048 game created by Gabriele Cirulli:
+
+  https://github.com/gabrielecirulli/2048
+
+The original is copyright (c) 2014 Gabriele Cirulli and released under the
+MIT License. This project reuses no code or assets from the original; the
+tribute is one of inspiration and respect.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ ruby test_game.rb
 61 runs, 189 assertions, 0 failures, 0 errors, 0 skips
 ```
 
+## License
+
+[CC BY-NC 4.0](LICENSE) — free to play, share, and modify; commercial use is not permitted. Inspired by the [original 2048](https://github.com/gabrielecirulli/2048) by Gabriele Cirulli.
+
 ## Project structure
 
 ```


### PR DESCRIPTION
Adds a `LICENSE` file and a one-liner badge in the README.

**License chosen: CC BY-NC 4.0**
- Anyone may play, share, adapt, and contribute
- Commercial use is prohibited
- Attribution is required by the license terms

The file also acknowledges Gabriele Cirulli's original 2048 (MIT-licensed) as the inspiration for this reimplementation, noting that no code or assets were taken from it.

> Two things to personalise before merging:
> - Replace `shingkid` in the copyright line with your real name if you prefer
> - Update the year if needed (currently 2026)

https://claude.ai/code/session_01PTPTEjR4v8wE1Z75izZhyx